### PR TITLE
display_scatter add palette argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     htmlwidgets,
     tidyselect,
     rlang,
-    purrr
+    purrr,
+    viridis
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)

--- a/R/display_scatter.r
+++ b/R/display_scatter.r
@@ -4,25 +4,24 @@
 #' Display method for a high performance 3D scatterplot.
 #' Performance is achieved through the use of Three.js / WebGL.
 #' @param mapping mapping created via `tour_aes()`. Currently only supports colour mapping.
-#' @param center If TRUE, center the projected data to (0, 0, 0).
+#' @param palette Colour palette to use with the colour aesthetic. Can be:
+#'  - A character vector of R colours. This should match the number of levels of the colour aesthetic, or the number of bins to use
+#'  for continuous colours.
+#'  - A function which takes the number of colours to use as input and returns a character vector of colour names and / or hex values as output.
 #' @param size point size, defaults to 1
+#' @param center If TRUE, center the projected data to (0, 0, 0).
+#' @param axes Whether to draw axes. TRUE or FALSE
 #' @param labels axis labels. Can be:
 #'  - `TRUE` to use column names for axis labels
 #'  - `FALSE` for no labels
 #'  - An unnamed vector of labels with the same length as `cols`
 #'  - A named vector in the form `c("h" = "head")`, where `head` is renamed to `h`
 #' @param edges A two column numeric matrix giving indices of ends of lines.
-#' @param axes Whether to draw axes. TRUE or FALSE
-#' @param palette Colour palette to use with the colour aesthetic. Can be:
-#'  - A character vector of R colours. This should match the number of levels of the colour aesthetic, or the number of bins to use
-#'  for continuous colours.
-#'  - A function which takes the number of colours to use as input and returns a character vector of colour names and / or hex values as output.
 #' @export
 #' @examples
 #' animate_tour(tourr::flea, -species, tourr::grand_tour(3), display_scatter())
-display_scatter <- function(mapping = NULL, center = TRUE, size = 1,
-                            labels = TRUE, edges = NULL, axes = TRUE,
-                            palette = viridis::viridis) {
+display_scatter <- function(mapping = NULL, palette = viridis::viridis, size = 1,
+                            center = TRUE, axes = TRUE, labels = TRUE, edges = NULL) {
     init <- function(data, col_spec) {
         default_mapping <- list(colour = character(0))
         mapping <- purrr::map(mapping, get_mapping_cols, data)

--- a/R/display_scatter.r
+++ b/R/display_scatter.r
@@ -13,18 +13,29 @@
 #'  - A named vector in the form `c("h" = "head")`, where `head` is renamed to `h`
 #' @param edges A two column numeric matrix giving indices of ends of lines.
 #' @param axes Whether to draw axes. TRUE or FALSE
+#' @param palette Colour palette to use with the colour aesthetic. Can be:
+#'  - A character vector of R colours. This should match the number of levels of the colour aesthetic, or the number of bins to use
+#'  for continuous colours.
+#'  - A function which takes the number of colours to use as input and returns a character vector of colour names and / or hex values as output.
 #' @export
 #' @examples
 #' animate_tour(tourr::flea, -species, tourr::grand_tour(3), display_scatter())
 display_scatter <- function(mapping = NULL, center = TRUE, size = 1,
-                            labels = TRUE, edges = NULL, axes = TRUE) {
+                            labels = TRUE, edges = NULL, axes = TRUE,
+                            palette = viridis::viridis) {
     init <- function(data, col_spec) {
         default_mapping <- list(colour = character(0))
         mapping <- purrr::map(mapping, get_mapping_cols, data)
 
         if ("colour" %in% names(mapping)) {
-            mapping[["colour"]] <- vec_to_colour(mapping[["colour"]])
+            colours <- vec_to_colour(mapping[["colour"]], palette)
         }
+        else {
+            colours <- vec_to_colour(rep("", nrow(data)), palette)
+        }
+
+        mapping[["colour"]] <- colours[["colours"]]
+        pal <- colours[["pal"]]
 
         mapping <- merge_defaults_list(mapping, default_mapping)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,7 +68,6 @@ vec_to_colour <- function(vec, pal) {
     } else {
       n <- length(pal)
     }
-
     vec <- cut(vec, n)
   }
 
@@ -84,17 +83,20 @@ vec_to_colour <- function(vec, pal) {
 
     if (is.function(pal)) {
       pal <- pal(length(levels(vec)))
-    } else if (length(pal) != length(levels(vec))) {
+    }
+
+    if (!is.character(pal)) {
+      rlang::abort("Invalid palette", x = "expected character vector", sprintf("got: %s", class(pal)))
+    }
+
+    if (length(pal) != length(levels(vec))) {
       rlang::abort("Number of colours in `palette` does not match the number of levels of the colour aesthetic")
     }
   }
 
-  if (is.character(pal)) {
-    # convert colour names and rgba values to rgb hex
-    pal <- col2hex(pal)
-  } else {
-    rlang::abort("Invalid `palette` argument", x = "expected function or character vector", sprintf("got: %s", class(pal)))
-  }
+
+  # convert colour names and rgba values to rgb hex
+  pal <- col2hex(pal)
 
   names(pal) <- levels(vec)
   vec <- unname(pal[vec])

--- a/man/display_scatter.Rd
+++ b/man/display_scatter.Rd
@@ -10,7 +10,8 @@ display_scatter(
   size = 1,
   labels = TRUE,
   edges = NULL,
-  axes = TRUE
+  axes = TRUE,
+  palette = viridis::viridis
 )
 }
 \arguments{
@@ -31,6 +32,13 @@ display_scatter(
 \item{edges}{A two column numeric matrix giving indices of ends of lines.}
 
 \item{axes}{Whether to draw axes. TRUE or FALSE}
+
+\item{palette}{Colour palette to use with the colour aesthetic. Can be:
+\itemize{
+\item A character vector of R colours. This should match the number of levels of the colour aesthetic, or the number of bins to use
+for continuous colours.
+\item A function which takes the number of colours to use as input and returns a character vector of colour names and / or hex values as output.
+}}
 }
 \description{
 Display method for a high performance 3D scatterplot.

--- a/man/display_scatter.Rd
+++ b/man/display_scatter.Rd
@@ -6,20 +6,29 @@
 \usage{
 display_scatter(
   mapping = NULL,
-  center = TRUE,
+  palette = viridis::viridis,
   size = 1,
-  labels = TRUE,
-  edges = NULL,
+  center = TRUE,
   axes = TRUE,
-  palette = viridis::viridis
+  labels = TRUE,
+  edges = NULL
 )
 }
 \arguments{
 \item{mapping}{mapping created via \code{tour_aes()}. Currently only supports colour mapping.}
 
-\item{center}{If TRUE, center the projected data to (0, 0, 0).}
+\item{palette}{Colour palette to use with the colour aesthetic. Can be:
+\itemize{
+\item A character vector of R colours. This should match the number of levels of the colour aesthetic, or the number of bins to use
+for continuous colours.
+\item A function which takes the number of colours to use as input and returns a character vector of colour names and / or hex values as output.
+}}
 
 \item{size}{point size, defaults to 1}
+
+\item{center}{If TRUE, center the projected data to (0, 0, 0).}
+
+\item{axes}{Whether to draw axes. TRUE or FALSE}
 
 \item{labels}{axis labels. Can be:
 \itemize{
@@ -30,15 +39,6 @@ display_scatter(
 }}
 
 \item{edges}{A two column numeric matrix giving indices of ends of lines.}
-
-\item{axes}{Whether to draw axes. TRUE or FALSE}
-
-\item{palette}{Colour palette to use with the colour aesthetic. Can be:
-\itemize{
-\item A character vector of R colours. This should match the number of levels of the colour aesthetic, or the number of bins to use
-for continuous colours.
-\item A function which takes the number of colours to use as input and returns a character vector of colour names and / or hex values as output.
-}}
 }
 \description{
 Display method for a high performance 3D scatterplot.


### PR DESCRIPTION
Adds a palette argument, which can be either a character vector of colours, or a function that will take an integer `n` as input and returns a character vector of colours of length `n`.

For simplicity, I haven't allowed using a named vector as mentioned in #35. Instead, the colours will be applied to levels in alphabetical order.

Basic test cases:

No palette or aesthetic specified. Defaults to dark purple colour from `viridis`:
```r
library(d3tourr)
animate_tour(
  tourr::flea, -species,
  display = display_scatter(),
  render_opts = list(max_bases = 10), tour_path = tourr::grand_tour(3)
)
```

Colour aesthetic is numeric, default viridis palette. Bins numeric values:
```r
animate_tour(
  tourr::olive, -area,
  display = display_scatter(tour_aes(colour = region)),
  render_opts = list(max_bases = 10), tour_path = tourr::grand_tour(3)
)
```

Use one of the built-in R palettes. Aesthetic is a character vector:
```r
animate_tour(
  tourr::flea, -species,
  display = display_scatter(tour_aes(colour = species), palette = palette.colors),
  render_opts = list(max_bases = 10), tour_path = tourr::grand_tour(3)
)
```

Custom palette specified by name:
```r
animate_tour(
  tourr::flea, -species,
  display = display_scatter(tour_aes(colour = species), palette = c("pink", "purple", "orange")),
  render_opts = list(max_bases = 10), tour_path = tourr::grand_tour(3)
)
```

